### PR TITLE
Various Bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ class ServerlessAWSBatch {
         .then(batchenvironment.generateAWSBatchTemplate)
         .then(batchtask.compileBatchTasks),
 
-      'after:package:createDeploymentArtifacts': () => BbPromise.bind(this)
+      'after:aws:deploy:deploy:updateStack': () => BbPromise.bind(this)
         .then(docker.buildDockerImage),
 
-      'before:aws:deploy:deploy:uploadArtifacts': () => BbPromise.bind(this)
+      'after:aws:deploy:finalize:cleanup': () => BbPromise.bind(this)
         .then(docker.pushDockerImageToECR),
 
       'before:remove:remove': () => BbPromise.bind(this)

--- a/lib/batchenvironment.js
+++ b/lib/batchenvironment.js
@@ -191,7 +191,7 @@ function generateBatchSpotFleetRole() {
            ]
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+          "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
         ]
       }
     }
@@ -243,6 +243,19 @@ function generateLambdaScheduleExecutionRole() {
                       "Ref": "${this.provider.naming.getBatchJobQueueLogicalId()}"
                     },
                     "arn:aws:batch:*:*:job-definition/*:*"
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DetachNetworkInterface",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeInstances"
+                  ],
+                  "Resource": [
+                    "*"
                   ]
                 }
               ]

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -67,28 +67,52 @@ function buildDockerImage() {
         )
     }
 
+    let additionalPythonPipInstallCommands = "";
+    if (this.serverless.service.provider.runtime === "python3.6") {
+      additionalPythonPipInstallCommands +=
+    `
+    RUN pip install -U six==1.11.0 -t /tmp --no-cache-dir
+    RUN pip install -U boto3 -t /tmp --no-cache-dir
+    RUN pip install -U botocore==1.12.188 -t /tmp --no-cache-dir
+    RUN pip install -U docutils -t /tmp --no-cache-dir
+    RUN pip install -U jmespath -t /tmp --no-cache-dir
+    RUN pip install -U python-dateutil -t /tmp --no-cache-dir
+    RUN pip install -U s3transfer -t /tmp --no-cache-dir
+    RUN pip install -U setuptools -t /tmp --no-cache-dir
+    `
+    };
+
     // Override some of the default lambci environmental variables.
     //   - Function Timeout and Function Memory are set by Env Variables on the Job Definition
     //   - Access Key and Secret are unset to that we use the role on the container that AWS provides
-    const dockerFileContents = `
+    var dockerFileContents = `
     FROM justinram11/lambda:build-${this.serverless.service.provider.runtime} AS builder
     USER root
     
     ${additionalRunCommands}
     COPY ${this.serverless.service.service}.zip /tmp
     RUN cd /tmp && unzip -q ${this.serverless.service.service}.zip && rm ${this.serverless.service.service}.zip
-    
+    ${additionalPythonPipInstallCommands}
+
     FROM justinram11/lambda:${this.serverless.service.provider.runtime}
     COPY --from=builder /tmp /var/task/${this.serverless.service.service}/
-    RUN rm -rf /tmp/*
+    RUN rm -rf /tmp/\*
     `;
     // custom ENTRYPOINT due to heap setting - entrypoint copied from original
-    if (this.serverless.service.provider.runtime === 'nodejs8.10') dockerFileContents.concat(
-        'ENTRYPOINT ["/var/lang/bin/node", "--expose-gc", "--max-semi-space-size=150", "--max-old-space-size=30000", "/var/runtime/node_modules/awslambda/index.js"]\n'
-    );
-    if (this.serverless.service.provider.runtime === 'nodejs10.x') dockerFileContents.concat(
-        'ENV NODE_OPTIONS="--max-old-space-size=30000"\n'
-    );
+    if (this.serverless.service.provider.runtime === 'nodejs8.10') {
+        dockerFileContents = dockerFileContents.concat(
+            'ENTRYPOINT ["/var/lang/bin/node", "--expose-gc", "--max-semi-space-size=150", "--max-old-space-size=30000", "/var/runtime/node_modules/awslambda/index.js"]\n'
+    )};
+    if (this.serverless.service.provider.runtime === 'nodejs10.x') {
+        dockerFileContents = dockerFileContents.concat(
+            'ENV NODE_OPTIONS="--max-old-space-size=30000"\n'
+    )};
+    if (this.serverless.service.provider.runtime === 'python3.6') {
+        dockerFileContents = dockerFileContents.concat(
+    `
+    ENV PYTHONPATH=/var/task/${this.serverless.service.service}:\${PYTHONPATH}
+    `
+    )};
     const servicePath = this.serverless.config.servicePath || '';
     const packagePath = path.join(servicePath || '.', '.serverless');
     const dockerFile = path.join(packagePath, 'Dockerfile');


### PR DESCRIPTION
1.Deprecated AmazonEC2SpotFleetRole
AmazonEC2SpotFleetRole is deprecated.I modified it to use AmazonEC2SpotFleetTaggingRole instead.

2.Allow EC2 in VPC
I added ENI permission so that EC2 can be built in VPC.

3.dockerFileContents is not updated
I fixed an issue where the dockerFileContents variable was not updated.

4.For python3.6
I modified it to use Python 3.6.

5.modify build and push ECR timing
I fixed it because Docker Push is done before the ECR repository is created.